### PR TITLE
Fix "Show Scope" command to include the left scope.

### DIFF
--- a/Commands/Show scope.plist
+++ b/Commands/Show scope.plist
@@ -6,9 +6,9 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>tr &lt;&lt;&lt; "$TM_SCOPE" ' ' '\n'
-if [[ -n "$TM_LEFT_SCOPE" ]]; then
+if [[ -n "$TM_SCOPE_LEFT" ]]; then
   echo $'\nLeft Scope:\n'
-  tr &lt;&lt;&lt; "$TM_LEFT_SCOPE" ' ' '\n'
+  tr &lt;&lt;&lt; "$TM_SCOPE_LEFT" ' ' '\n'
 fi
 </string>
 	<key>input</key>


### PR DESCRIPTION
The left scope is represented by the `TM_SCOPE_LEFT` environment variable, not `TM_LEFT_SCOPE`, meaning that the left scope never actually showed up.
