### PR TITLE
Only show left scope when it’s different from right scope

### DIFF
--- a/Commands/Show scope.plist
+++ b/Commands/Show scope.plist
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>tr &lt;&lt;&lt; "$TM_SCOPE" ' ' '\n'
-if [[ -n "$TM_SCOPE_LEFT" ]]; then
+if [[ -n "$TM_SCOPE_LEFT" &amp;&amp; "$TM_SCOPE_LEFT" != "$TM_SCOPE" ]]; then
   echo $'\nLeft Scope:\n'
   tr &lt;&lt;&lt; "$TM_SCOPE_LEFT" ' ' '\n'
 fi


### PR DESCRIPTION
A lot of times, there is a left scope but it’s the same as the right scope.
Displaying both seems to imply some kind of difference, which may not exist, so with this change we only show the left scope when it *differs* from the right scope.